### PR TITLE
Fix manual save missing list ID

### DIFF
--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -212,8 +212,10 @@ export const ScanPage: React.FC = () => {
           error={scanError}
           clearResult={clearRecentScan}
           onSave={(updates) => {
-            if (lastScannedPart) {
-              addItem({ ...lastScannedPart, ...updates });
+            if (lastScannedPart && currentList) {
+              // Include the current list ID when saving manually so RLS policies
+              // that rely on list ownership pass correctly
+              addItem({ ...lastScannedPart, ...updates, list_id: currentList.id });
             }
           }}
         />


### PR DESCRIPTION
## Summary
- ensure manual save to list includes the current list ID

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687dac00f90083308e3638ea61eca1f7

------
The RLS failure occurred when manually saving a scan result.
Before the fix, the onSave handler in ScanPage.tsx inserted the scan data without specifying the list ID:

```
onSave={(updates) => {
  if (lastScannedPart) {
    addItem({ ...lastScannedPart, ...updates });
  }
}}
```

Since the scan_items table’s security policy checks that a new row’s list_id belongs to the current user, omitting this field caused Supabase to reject the insert with “row level security policy” errors.

The PR modifies the handler to include the active list’s ID:

```
onSave={(updates) => {
  if (lastScannedPart && currentList) {
    // Include the current list ID when saving manually so RLS policies
    // that rely on list ownership pass correctly
    addItem({ ...lastScannedPart, ...updates, list_id: currentList.id });
  }
}}
```

By adding list_id: currentList.id, the new item matches the RLS requirements, so the insert succeeds. This resolves the “violates row-level security policy” error when users manually save items to a list.